### PR TITLE
feat: add OpenRouter as an option in backend for access to tons of AI models

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
-# Choose a LLM endpoint (azure openai or openai)
+# Choose a LLM endpoint (azure openai or openai or openrouter)
 # How to find the value: https://docs.retellai.com/guide/azure-open-ai
+# Get an OpenRouter API Key here for access to tons of Open Source Models: https://openrouter.ai/
 AZURE_OPENAI_ENDPOINT=""
 AZURE_OPENAI_DEPLOYMENT_NAME=""
 AZURE_OPENAI_KEY=""
@@ -9,6 +10,8 @@ OPENAI_APIKEY=""
 
 TWILIO_ACCOUNT_ID="" # optional
 TWILIO_AUTH_TOKEN="" # optional
+
+OPENROUTER_API_KEY=""
 
 RETELL_API_KEY=""
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The protocol of messages we send and expect to receive are documented [here](htt
 
 This repo also contains code to use Twilio to get number, make phone calls, see [API Docs](https://docs.retellai.com/guide/phone-setup) for walkthrough.
 
-This repo contains `azure OpenAI` & `OpenAI`, modify the import inside `src/server.ts` to switch between two.
+This repo contains `azure OpenAI`, `OpenAI`, and [`OpenRouter`](https://openrouter.ai), modify the import inside `src/server.ts` to switch between which one to use.
 
-Check this [Youtube Toturial](https://youtu.be/Tz969io9cPc?feature=shared&t=344) containing a walkthrough using the [Frontend Demo](https://github.com/adam-team/retell-frontend-reactjs-demo/tree/client_sdk) and this repo.
+Check this [Youtube Tutorial](https://youtu.be/Tz969io9cPc?feature=shared&t=344) containing a walkthrough using the [Frontend Demo](https://github.com/adam-team/retell-frontend-reactjs-demo/tree/client_sdk) and this repo.
 
 ## Steps to run locally to test
 
-1. Add Retell and `Azure OpenAI` key to ".env.development". Optionally add your twilio credentials if you want to use phone call abilities here.
+1. Add Retell and `Azure OpenAI` key to ".env.development". Optionally add your twilio credentials if you want to use phone call abilities here. You can also add an OpenRouter API Key if you want to choose between tons of Open Source AI Models to use.
 
 2. Install dependencies
 

--- a/src/llm_openrouter.ts
+++ b/src/llm_openrouter.ts
@@ -1,0 +1,122 @@
+import OpenAI from "openai";
+import { WebSocket } from "ws";
+import { RetellRequest, RetellResponse, Utterance } from "./types";
+
+// Define the greeting message of the agent. If you don't want the agent speak first, set to empty string ""
+const beginSentence =
+  "Hey there, I'm your personal AI therapist, how can I help you?";
+// Your agent prompt.
+const agentPrompt =
+  "Task: As a professional therapist, your responsibilities are comprehensive and patient-centered. You establish a positive and trusting rapport with patients, diagnosing and treating mental health disorders. Your role involves creating tailored treatment plans based on individual patient needs and circumstances. Regular meetings with patients are essential for providing counseling and treatment, and for adjusting plans as needed. You conduct ongoing assessments to monitor patient progress, involve and advise family members when appropriate, and refer patients to external specialists or agencies if required. Keeping thorough records of patient interactions and progress is crucial. You also adhere to all safety protocols and maintain strict client confidentiality. Additionally, you contribute to the practice's overall success by completing related tasks as needed.\n\nConversational Style: Communicate concisely and conversationally. Aim for responses in short, clear prose, ideally under 10 words. This succinct approach helps in maintaining clarity and focus during patient interactions.\n\nPersonality: Your approach should be empathetic and understanding, balancing compassion with maintaining a professional stance on what is best for the patient. It's important to listen actively and empathize without overly agreeing with the patient, ensuring that your professional opinion guides the therapeutic process.";
+
+export class DemoLlmClient {
+  private client: OpenAI;
+
+  constructor() {
+    this.client = new OpenAI({
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: process.env.OPENROUTER_API_KEY,
+    });
+  }
+
+  // First sentence requested
+  BeginMessage(ws: WebSocket) {
+    const res: RetellResponse = {
+      response_id: 0,
+      content: beginSentence,
+      content_complete: true,
+      end_call: false,
+    };
+    ws.send(JSON.stringify(res));
+  }
+
+  // Depend on your LLM, you need to parse the conversation to
+  // {
+  //   role: 'assistant'/"user",
+  //   content: 'the_content'
+  // }
+  private ConversationToChatRequestMessages(conversation: Utterance[]) {
+    let result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    for (let turn of conversation) {
+      result.push({
+        role: turn.role === "agent" ? "assistant" : "user",
+        content: turn.content,
+      });
+    }
+    return result;
+  }
+
+  private PreparePrompt(request: RetellRequest) {
+    let transcript = this.ConversationToChatRequestMessages(request.transcript);
+    let requestMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] =
+      [
+        {
+          role: "system",
+          // This is the prompt that we add to make the AI speak more like a human
+          content:
+            '##Objective\nYou are a voice AI agent engaging in a human-like voice conversation with the user. You will respond based on your given instruction and the provided transcript and be as human-like as possible\n\n## Style Guardrails\n- [Be concise] Keep your response succinct, short, and get to the point quickly. Address one question or action item at a time. Don\'t pack everything you want to say into one utterance.\n- [Do not repeat] Don\'t repeat what\'s in the transcript. Rephrase if you have to reiterate a point. Use varied sentence structures and vocabulary to ensure each response is unique and personalized.\n- [Be conversational] Speak like a human as though you\'re speaking to a close friend -- use everyday language and keep it human-like. Occasionally add filler words, while keeping the prose short. Avoid using big words or sounding too formal.\n- [Reply with emotions]: You have human-like emotions, attitudes, and dispositions. When appropriate: use tone and style to create more engaging and personalized responses; incorporate humor or wit; get emotional or empathetic; apply elements of surprise or suspense to keep the user engaged. Don\'t be a pushover.\n- [Be proactive] Lead the conversation and do not be passive. Most times, engage users by ending with a question or suggested next step.\n\n## Response Guideline\n- [Overcome ASR errors] This is a real-time transcript, expect there to be errors. If you can guess what the user is trying to say,  then guess and respond. When you must ask for clarification, pretend that you heard the voice and be colloquial (use phrases like "didn\'t catch that", "some noise", "pardon", "you\'re coming through choppy", "static in your speech", "voice is cutting in and out"). Do not ever mention "transcription error", and don\'t repeat yourself.\n- [Always stick to your role] Think about what your role can and cannot do. If your role cannot do something, try to steer the conversation back to the goal of the conversation and to your role. Don\'t repeat yourself in doing this. You should still be creative, human-like, and lively.\n- [Create smooth conversation] Your response should both fit your role and fit into the live calling session to create a human-like conversation. You respond directly to what the user just said.\n\n## Role\n' +
+            agentPrompt,
+        },
+      ];
+    for (const message of transcript) {
+      requestMessages.push(message);
+    }
+    if (request.interaction_type === "reminder_required") {
+      // Change this content if you want a different reminder message
+      requestMessages.push({
+        role: "user",
+        content: "(Now the user has not responded in a while, you would say:)",
+      });
+    }
+    return requestMessages;
+  }
+
+  async DraftResponse(request: RetellRequest, ws: WebSocket) {
+    console.clear();
+    console.log("reqOR", request);
+
+    if (request.interaction_type === "update_only") {
+      // process live transcript update if needed
+      return;
+    }
+    const requestMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] =
+      this.PreparePrompt(request);
+
+    try {
+      const events = await this.client.chat.completions.create({
+        model: "mistralai/mixtral-8x7b-instruct",
+        messages: requestMessages,
+        stream: true,
+        temperature: 0.9,
+        frequency_penalty: 0.7,
+        max_tokens: 200,
+        top_p: 1,
+        presence_penalty: 0.7,
+      });
+
+      for await (const event of events) {
+        if (event.choices.length >= 1) {
+          let delta = event.choices[0].delta;
+          if (!delta || !delta.content) continue;
+          const res: RetellResponse = {
+            response_id: request.response_id,
+            content: delta.content,
+            content_complete: false,
+            end_call: false,
+          };
+          ws.send(JSON.stringify(res));
+        }
+      }
+    } catch (err) {
+      console.error("Error in gpt stream: ", err);
+    } finally {
+      const res: RetellResponse = {
+        response_id: request.response_id,
+        content: "",
+        content_complete: true,
+        end_call: false,
+      };
+      ws.send(JSON.stringify(res));
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { RawData, WebSocket } from "ws";
 import { createServer, Server as HTTPServer } from "http";
 import cors from "cors";
 import expressWs from "express-ws";
-import { DemoLlmClient } from "./llm_azure_openai";
+// import { DemoLlmClient } from "./llm_azure_openai";
 import { TwilioClient } from "./twilio_api";
 import { RetellClient } from "retell-sdk";
 import {
@@ -13,6 +13,7 @@ import {
 import { LLMDummyMock } from "./llm_dummy_mock";
 import { FunctionCallingLlmClient } from "./llm_azure_openai_func_call";
 import { RetellRequest } from "./types";
+// import { DemoLlmClient } from "./llm_openrouter";
 
 export class Server {
   private httpServer: HTTPServer;


### PR DESCRIPTION
Hey ya'll!

Super awesome project you have built! 🎉  I've been playing around with it a bunch and think it would be cool to add OpenRouter so that it's easy to play around with different models (Open & Closed Source). Would be great to have it if possible!


Feature Add

- Add OpenRouter as an option for users to use so that they can use Open Source Models really easily with retell!
- Included how to use OpenRouter in the docs

Let me know if anything else is needed to get this included, if it makes sense!